### PR TITLE
Fix #1: stop double-counting overlapping categories

### DIFF
--- a/lib/phx_stats/analyzer.ex
+++ b/lib/phx_stats/analyzer.ex
@@ -28,16 +28,31 @@ defmodule PhxStats.Analyzer do
   @doc """
   Builds a full report given a list of `{name, glob}` categories and a test glob.
 
-  Categories that match no files are dropped. The total excludes test files —
-  tests are counted separately so the code-to-test ratio is meaningful.
+  Each source file is assigned to the **first** category whose glob matches it,
+  so overlapping patterns do not double-count. Categories that end up with no
+  files are dropped. The total excludes test files — tests are counted
+  separately so the code-to-test ratio is meaningful.
   """
   @spec analyze([{String.t(), String.t()}], String.t()) :: report()
   def analyze(categories, test_pattern) do
-    category_stats =
-      categories
-      |> Enum.map(fn {name, pattern} -> {name, analyze_pattern(pattern)} end)
-      |> Enum.reject(fn {_name, stats} -> stats.files == 0 end)
+    {category_stats, _assigned} =
+      Enum.reduce(categories, {[], MapSet.new()}, fn {name, pattern}, {acc, taken} ->
+        files =
+          pattern
+          |> find_files()
+          |> Enum.reject(&MapSet.member?(taken, &1))
 
+        case files do
+          [] ->
+            {acc, taken}
+
+          _ ->
+            stats = files |> Enum.map(&analyze_file/1) |> sum_stats()
+            {[{name, stats} | acc], MapSet.union(taken, MapSet.new(files))}
+        end
+      end)
+
+    category_stats = Enum.reverse(category_stats)
     test_stats = analyze_pattern(test_pattern)
 
     total =

--- a/lib/phx_stats/config.ex
+++ b/lib/phx_stats/config.ex
@@ -13,6 +13,10 @@ defmodule PhxStats.Config do
         ],
         test_pattern: "test/**/*_test.exs"
 
+  Each source file is assigned to the **first** category whose glob matches it,
+  so overlapping patterns are safe — list more specific categories first and
+  use a broad fallback (e.g. `lib/**/*.ex`) last to catch the rest.
+
   If no configuration is provided, sensible Phoenix defaults are used (see
   `default_categories/0`).
   """

--- a/test/phx_stats/analyzer_test.exs
+++ b/test/phx_stats/analyzer_test.exs
@@ -126,5 +126,28 @@ defmodule PhxStats.AnalyzerTest do
         assert report.tests.files == 1
       end)
     end
+
+    test "assigns each file to the first matching category and Total counts it once",
+         %{tmp: tmp} do
+      File.cd!(tmp, fn ->
+        report =
+          Analyzer.analyze(
+            [
+              {"Controllers", "lib/**/controllers/**/*.ex"},
+              {"Libraries", "lib/**/*.ex"}
+            ],
+            "test/**/*_test.exs"
+          )
+
+        assert {"Controllers", controllers_stats} =
+                 Enum.find(report.categories, &match?({"Controllers", _}, &1))
+
+        assert controllers_stats.files == 1
+        refute Enum.find(report.categories, &match?({"Libraries", _}, &1))
+
+        assert report.total.files == 1
+        assert report.total.lines == controllers_stats.lines
+      end)
+    end
   end
 end


### PR DESCRIPTION
## Summary
- Each source file is now assigned to the **first** category whose glob matches, so overlapping patterns (including the default `Libraries` catch-all) no longer inflate the `Total` row or skew the code-to-test ratio.
- Documented the first-match semantics in `PhxStats.Config`'s moduledoc.
- Added a regression test covering an overlapping `Controllers` + `Libraries` config.

Closes #1

## Test plan
- [x] `mix test` (15 tests, 0 failures)
- [ ] Manual: run `mix stats` against a Phoenix app with overlapping defaults and verify `Total.files` equals the actual unique file count under `lib/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)