### PR TITLE
Fix #2: exclude comments from module and function counts

### DIFF
--- a/lib/phx_stats/analyzer.ex
+++ b/lib/phx_stats/analyzer.ex
@@ -70,15 +70,14 @@ defmodule PhxStats.Analyzer do
   @spec analyze_content(String.t()) :: stats()
   def analyze_content(content) do
     lines = String.split(content, "\n")
-
-    loc = Enum.count(lines, fn line -> not blank_or_comment?(line) end)
+    code_lines = Enum.reject(lines, &blank_or_comment?/1)
 
     %{
       files: 1,
       lines: length(lines),
-      loc: loc,
-      modules: count_lines_matching(lines, ~r/^\s*defmodule\s/),
-      functions: count_lines_matching(lines, ~r/^\s*def(p|macro|macrop)?\s/)
+      loc: length(code_lines),
+      modules: count_lines_matching(code_lines, ~r/^\s*defmodule\s/),
+      functions: count_lines_matching(code_lines, ~r/^\s*def(p|macro|macrop)?\s/)
     }
   end
 

--- a/test/phx_stats/analyzer_test.exs
+++ b/test/phx_stats/analyzer_test.exs
@@ -56,6 +56,20 @@ defmodule PhxStats.AnalyzerTest do
       assert stats.functions == 0
     end
 
+    test "ignores `def`/`defmodule` occurrences inside comments" do
+      content = """
+      # def fake_function, do: :ok
+      # defmodule FakeModule do
+      defmodule Real do
+        def real, do: :ok
+      end
+      """
+
+      stats = Analyzer.analyze_content(content)
+      assert stats.modules == 1
+      assert stats.functions == 1
+    end
+
     test "empty content yields zero LOC and one file" do
       stats = Analyzer.analyze_content("")
       assert stats.files == 1


### PR DESCRIPTION
## Summary
- `analyze_content/1` now filters blank/comment lines once and runs both `defmodule` and `def*` counters against the filtered list — so a `# def foo` line in a docstring no longer inflates the function count.
- Added a regression test covering `def` / `defmodule` occurrences inside comments.

Closes #2

## Test plan
- [x] `mix test` (15 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)