### PR TITLE
Fix #3: surface unreadable-file errors via stderr warning

### DIFF
--- a/lib/phx_stats/analyzer.ex
+++ b/lib/phx_stats/analyzer.ex
@@ -1,6 +1,10 @@
 defmodule PhxStats.Analyzer do
   @moduledoc """
-  Pure analysis functions: count lines, modules, and functions in Elixir source files.
+  Analysis functions: count lines, modules, and functions in Elixir source files.
+
+  All functions are pure with one exception: `analyze_file/1` writes to stderr
+  if a file cannot be read, so a single unreadable file does not silently drop
+  out of the totals.
 
   ## What counts as a function
 
@@ -93,7 +97,7 @@ defmodule PhxStats.Analyzer do
   @doc """
   Analyzes a single file.
 
-  Emits a warning to stderr and returns zeroed stats if the file cannot be
+  Writes a message to stderr and returns zeroed stats if the file cannot be
   read — so that one unreadable file doesn't abort an entire `mix stats` run,
   but the failure stays visible.
   """
@@ -104,7 +108,12 @@ defmodule PhxStats.Analyzer do
         analyze_content(content)
 
       {:error, reason} ->
-        IO.warn("phx_stats: could not read #{file}: #{:file.format_error(reason)}", [])
+        IO.write(
+          :stderr,
+          "phx_stats: could not read #{inspect(file)}: " <>
+            "#{:file.format_error(reason)}\n"
+        )
+
         @empty
     end
   end

--- a/lib/phx_stats/analyzer.ex
+++ b/lib/phx_stats/analyzer.ex
@@ -90,12 +90,22 @@ defmodule PhxStats.Analyzer do
     |> sum_stats()
   end
 
-  @doc "Analyzes a single file. Returns zeroed stats if the file cannot be read."
+  @doc """
+  Analyzes a single file.
+
+  Emits a warning to stderr and returns zeroed stats if the file cannot be
+  read — so that one unreadable file doesn't abort an entire `mix stats` run,
+  but the failure stays visible.
+  """
   @spec analyze_file(Path.t()) :: stats()
   def analyze_file(file) do
     case File.read(file) do
-      {:ok, content} -> analyze_content(content)
-      {:error, _} -> @empty
+      {:ok, content} ->
+        analyze_content(content)
+
+      {:error, reason} ->
+        IO.warn("phx_stats: could not read #{file}: #{:file.format_error(reason)}", [])
+        @empty
     end
   end
 

--- a/test/phx_stats/analyzer_test.exs
+++ b/test/phx_stats/analyzer_test.exs
@@ -83,8 +83,16 @@ defmodule PhxStats.AnalyzerTest do
   @empty_stats %{files: 0, lines: 0, loc: 0, modules: 0, functions: 0}
 
   describe "analyze_file/1" do
-    test "returns empty stats when file is missing" do
-      assert Analyzer.analyze_file("does/not/exist.ex") == @empty_stats
+    import ExUnit.CaptureIO
+
+    test "warns and returns empty stats when file is missing" do
+      log =
+        capture_io(:stderr, fn ->
+          assert Analyzer.analyze_file("does/not/exist.ex") == @empty_stats
+        end)
+
+      assert log =~ "phx_stats"
+      assert log =~ "does/not/exist.ex"
     end
   end
 


### PR DESCRIPTION
## Summary
- `Analyzer.analyze_file/1` now emits a stderr warning naming the file and the reason when `File.read/1` fails, then returns zeros and continues — so one bad file doesn't abort the whole run, but the failure no longer hides.
- Updated the existing missing-file test to assert the warning is produced.

Closes #3

## Test plan
- [x] `mix test` (14 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)