### PR TITLE
Fix #4: recognise defguard/defdelegate/defn variants

### DIFF
--- a/lib/phx_stats/analyzer.ex
+++ b/lib/phx_stats/analyzer.ex
@@ -1,6 +1,15 @@
 defmodule PhxStats.Analyzer do
   @moduledoc """
   Pure analysis functions: count lines, modules, and functions in Elixir source files.
+
+  ## What counts as a function
+
+  The function counter recognises the following definition forms:
+  `def`, `defp`, `defmacro`, `defmacrop`, `defguard`, `defguardp`,
+  `defdelegate`, `defn`, and `defnp`.
+
+  Forms that don't define callable functions — `defstruct`, `defprotocol`,
+  `defimpl`, `defexception`, `defrecord` — are intentionally not counted.
   """
 
   @type stats :: %{

--- a/lib/phx_stats/analyzer.ex
+++ b/lib/phx_stats/analyzer.ex
@@ -66,6 +66,12 @@ defmodule PhxStats.Analyzer do
     end
   end
 
+  # Function-defining forms recognised by the counter.
+  # Note: `defstruct`, `defprotocol`, `defimpl`, `defexception`, `defrecord`
+  # are intentionally excluded — they don't define callable functions.
+  @function_keywords ~w(def defp defmacro defmacrop defguard defguardp defdelegate defn defnp)
+  @function_regex ~r/^\s*(?:#{Enum.join(@function_keywords, "|")})\s/
+
   @doc "Analyzes a string of Elixir source code."
   @spec analyze_content(String.t()) :: stats()
   def analyze_content(content) do
@@ -78,7 +84,7 @@ defmodule PhxStats.Analyzer do
       lines: length(lines),
       loc: loc,
       modules: count_lines_matching(lines, ~r/^\s*defmodule\s/),
-      functions: count_lines_matching(lines, ~r/^\s*def(p|macro|macrop)?\s/)
+      functions: count_lines_matching(lines, @function_regex)
     }
   end
 

--- a/test/phx_stats/analyzer_test.exs
+++ b/test/phx_stats/analyzer_test.exs
@@ -45,6 +45,21 @@ defmodule PhxStats.AnalyzerTest do
       assert stats.functions == 2
     end
 
+    test "counts defguard, defguardp, defdelegate, and defn variants" do
+      content = """
+      defmodule M do
+        defguard a(x) when is_integer(x)
+        defguardp b(x) when is_atom(x)
+        defdelegate c(x), to: List
+        defn d(x), do: x
+        defnp e(x), do: x
+      end
+      """
+
+      stats = Analyzer.analyze_content(content)
+      assert stats.functions == 5
+    end
+
     test "does not count `defmodule` lines as functions" do
       stats = Analyzer.analyze_content("defmodule Foo do\nend\n")
       assert stats.modules == 1


### PR DESCRIPTION
## Summary
- Added `defguard`, `defguardp`, `defdelegate`, `defn`, and `defnp` to the function regex so real Elixir/Nx/Phoenix codebases aren't undercounted.
- Centralised the keyword list as a module attribute (`@function_keywords`) so the supported set is easy to read, extend, and grep for.
- Documented in a comment why `defstruct`/`defprotocol`/`defimpl`/etc. are intentionally excluded.
- Added a regression test for the new variants.

Closes #4

## Test plan
- [x] `mix test` (15 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)