### PR TITLE
Fix #6: parse CLI args in mix stats task

### DIFF
--- a/lib/mix/tasks/stats.ex
+++ b/lib/mix/tasks/stats.ex
@@ -8,6 +8,17 @@ defmodule Mix.Tasks.Stats do
   ## Usage
 
       $ mix stats
+      $ mix stats --test-pattern "test/**/*_test.exs"
+      $ mix stats --category "Workers=lib/**/workers/**/*.ex" \\
+                  --category "Libraries=lib/**/*.ex"
+
+  ## Options
+
+    * `--test-pattern PATTERN` — override the configured test glob.
+    * `--category NAME=GLOB` — replace the configured category list.
+      Repeat the flag once per category; first-match-wins ordering applies.
+      If no `--category` flag is given, the configured categories are used.
+    * `--help`, `-h` — show this help and exit.
 
   ## Configuration
 
@@ -43,12 +54,60 @@ defmodule Mix.Tasks.Stats do
 
   @shortdoc "Shows code statistics for the project"
 
+  @switches [test_pattern: :string, category: :keep, help: :boolean]
+  @aliases [h: :help]
+
   @impl Mix.Task
   @spec run([String.t()]) :: :ok
-  def run(_args) do
-    [categories: Config.categories(), test_pattern: Config.test_pattern()]
-    |> Analyzer.analyze()
-    |> Formatter.format()
-    |> IO.puts()
+  def run(args) do
+    {opts, rest, invalid} = OptionParser.parse(args, strict: @switches, aliases: @aliases)
+
+    cond do
+      invalid != [] ->
+        Mix.raise(
+          "phx_stats: unknown option(s): " <>
+            Enum.map_join(invalid, ", ", fn {flag, _} -> flag end) <>
+            ". Run `mix help stats` for usage."
+        )
+
+      rest != [] ->
+        Mix.raise(
+          "phx_stats: unexpected argument(s): " <>
+            Enum.join(rest, ", ") <> ". Run `mix help stats` for usage."
+        )
+
+      opts[:help] ->
+        Mix.shell().info(@moduledoc)
+        :ok
+
+      true ->
+        [categories: resolve_categories(opts), test_pattern: resolve_test_pattern(opts)]
+        |> Analyzer.analyze()
+        |> Formatter.format()
+        |> IO.puts()
+    end
+  end
+
+  defp resolve_categories(opts) do
+    case Keyword.get_values(opts, :category) do
+      [] -> Config.categories()
+      values -> Enum.map(values, &parse_category/1)
+    end
+  end
+
+  defp parse_category(spec) do
+    case String.split(spec, "=", parts: 2) do
+      [name, glob] when name != "" and glob != "" ->
+        {name, glob}
+
+      _ ->
+        Mix.raise(
+          "phx_stats: invalid --category #{inspect(spec)}, expected NAME=GLOB"
+        )
+    end
+  end
+
+  defp resolve_test_pattern(opts) do
+    Keyword.get(opts, :test_pattern, Config.test_pattern())
   end
 end

--- a/test/mix/tasks/stats_test.exs
+++ b/test/mix/tasks/stats_test.exs
@@ -1,0 +1,86 @@
+defmodule Mix.Tasks.StatsTest do
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureIO
+
+  setup do
+    tmp = Path.join(System.tmp_dir!(), "phx_stats_task_#{System.unique_integer([:positive])}")
+    File.mkdir_p!(Path.join(tmp, "lib/app/controllers"))
+    File.mkdir_p!(Path.join(tmp, "test"))
+
+    File.write!(Path.join(tmp, "lib/app/controllers/page_controller.ex"), """
+    defmodule App.PageController do
+      def index(conn, _), do: conn
+    end
+    """)
+
+    File.write!(Path.join(tmp, "test/page_test.exs"), """
+    defmodule App.PageTest do
+      use ExUnit.Case
+      test "ok", do: assert true
+    end
+    """)
+
+    on_exit(fn -> File.rm_rf!(tmp) end)
+
+    {:ok, tmp: tmp}
+  end
+
+  test "--help prints usage and does not run analysis" do
+    output =
+      capture_io(fn ->
+        Mix.Tasks.Stats.run(["--help"])
+      end)
+
+    assert output =~ "## Usage"
+    assert output =~ "## Options"
+    # No actual analysis ran — only the moduledoc, no live separator with totals.
+    refute output =~ ~r/^Code LOC:/m
+  end
+
+  test "--category overrides the configured categories", %{tmp: tmp} do
+    File.cd!(tmp, fn ->
+      output =
+        capture_io(fn ->
+          Mix.Tasks.Stats.run([
+            "--category",
+            "Controllers=lib/**/controllers/**/*.ex",
+            "--test-pattern",
+            "test/**/*_test.exs"
+          ])
+        end)
+
+      assert output =~ "Controllers"
+      assert output =~ "Code to Test Ratio"
+    end)
+  end
+
+  test "--test-pattern overrides the configured test glob", %{tmp: tmp} do
+    File.cd!(tmp, fn ->
+      output =
+        capture_io(fn ->
+          Mix.Tasks.Stats.run([
+            "--category",
+            "Controllers=lib/**/*.ex",
+            "--test-pattern",
+            "test/**/*_test.exs"
+          ])
+        end)
+
+      assert output =~ ~r/Test LOC: \d+/
+      assert output =~ "Code to Test Ratio"
+    end)
+  end
+
+  test "invalid --category spec raises a clear error" do
+    assert_raise Mix.Error, ~r/invalid --category/, fn ->
+      Mix.Tasks.Stats.run(["--category", "no-equals-sign"])
+    end
+  end
+
+  test "unknown option raises" do
+    assert_raise Mix.Error, ~r/unknown option/, fn ->
+      Mix.Tasks.Stats.run(["--bogus"])
+    end
+  end
+end


### PR DESCRIPTION
## Summary
`mix stats` previously ignored everything on the command line. It now accepts:

- `--test-pattern PATTERN` — override the configured test glob
- `--category NAME=GLOB` — replace categories (repeatable; first-match-wins ordering)
- `--help` / `-h` — print usage from the moduledoc

OptionParser runs in `:strict` mode so unknown flags or stray positional args raise `Mix.Error` with a clear message instead of being silently ignored.

Added `Mix.Tasks.StatsTest` covering: --help, --category override, --test-pattern override, invalid `--category` spec, unknown flag.

Closes #6

## Test plan
- [x] `mix test` (19 tests, 0 failures)
- [ ] Manual: `mix stats --help`, `mix stats --category "Workers=lib/**/workers/**/*.ex"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)