### PR TITLE
Refactor #8: reshape Analyzer.analyze to keyword options

### DIFF
--- a/lib/mix/tasks/stats.ex
+++ b/lib/mix/tasks/stats.ex
@@ -46,8 +46,8 @@ defmodule Mix.Tasks.Stats do
   @impl Mix.Task
   @spec run([String.t()]) :: :ok
   def run(_args) do
-    Config.categories()
-    |> Analyzer.analyze(Config.test_pattern())
+    [categories: Config.categories(), test_pattern: Config.test_pattern()]
+    |> Analyzer.analyze()
     |> Formatter.format()
     |> IO.puts()
   end

--- a/lib/phx_stats/analyzer.ex
+++ b/lib/phx_stats/analyzer.ex
@@ -30,16 +30,28 @@ defmodule PhxStats.Analyzer do
 
   @empty %{files: 0, lines: 0, loc: 0, modules: 0, functions: 0}
 
+  @type option ::
+          {:categories, [{String.t(), String.t()}]}
+          | {:test_pattern, String.t()}
+
   @doc """
-  Builds a full report given a list of `{name, glob}` categories and a test glob.
+  Builds a full report.
+
+  ## Options
+
+    * `:categories` (required) — a list of `{name, glob}` pairs.
+    * `:test_pattern` (required) — a wildcard glob for test files.
 
   Each source file is assigned to the **first** category whose glob matches it,
   so overlapping patterns do not double-count. Categories that end up with no
   files are dropped. The total excludes test files — tests are counted
   separately so the code-to-test ratio is meaningful.
   """
-  @spec analyze([{String.t(), String.t()}], String.t()) :: report()
-  def analyze(categories, test_pattern) do
+  @spec analyze([option()]) :: report()
+  def analyze(opts) when is_list(opts) do
+    categories = Keyword.fetch!(opts, :categories)
+    test_pattern = Keyword.fetch!(opts, :test_pattern)
+
     {category_stats, _assigned} =
       Enum.reduce(categories, {[], MapSet.new()}, fn {name, pattern}, {acc, taken} ->
         files =

--- a/lib/phx_stats/analyzer.ex
+++ b/lib/phx_stats/analyzer.ex
@@ -49,6 +49,7 @@ defmodule PhxStats.Analyzer do
   """
   @spec analyze([option()]) :: report()
   def analyze(opts) when is_list(opts) do
+    opts = Keyword.validate!(opts, [:categories, :test_pattern])
     categories = Keyword.fetch!(opts, :categories)
     test_pattern = Keyword.fetch!(opts, :test_pattern)
 

--- a/test/phx_stats/analyzer_test.exs
+++ b/test/phx_stats/analyzer_test.exs
@@ -100,6 +100,23 @@ defmodule PhxStats.AnalyzerTest do
     end
   end
 
+  describe "analyze/1 input validation" do
+    test "raises on missing required option" do
+      assert_raise KeyError, fn -> Analyzer.analyze(test_pattern: "test/**/*_test.exs") end
+      assert_raise KeyError, fn -> Analyzer.analyze(categories: []) end
+    end
+
+    test "raises on unknown option keys" do
+      assert_raise ArgumentError, fn ->
+        Analyzer.analyze(
+          categories: [],
+          test_pattern: "x",
+          catagories: []
+        )
+      end
+    end
+  end
+
   describe "analyze/1 (integration with the file system)" do
     setup do
       tmp = Path.join(System.tmp_dir!(), "phx_stats_#{System.unique_integer([:positive])}")
@@ -149,11 +166,11 @@ defmodule PhxStats.AnalyzerTest do
       File.cd!(tmp, fn ->
         report =
           Analyzer.analyze(
-            [
+            categories: [
               {"Controllers", "lib/**/controllers/**/*.ex"},
               {"Libraries", "lib/**/*.ex"}
             ],
-            "test/**/*_test.exs"
+            test_pattern: "test/**/*_test.exs"
           )
 
         assert {"Controllers", controllers_stats} =

--- a/test/phx_stats/analyzer_test.exs
+++ b/test/phx_stats/analyzer_test.exs
@@ -100,7 +100,7 @@ defmodule PhxStats.AnalyzerTest do
     end
   end
 
-  describe "analyze/2 (integration with the file system)" do
+  describe "analyze/1 (integration with the file system)" do
     setup do
       tmp = Path.join(System.tmp_dir!(), "phx_stats_#{System.unique_integer([:positive])}")
       File.mkdir_p!(Path.join(tmp, "lib/app/controllers"))
@@ -128,11 +128,11 @@ defmodule PhxStats.AnalyzerTest do
       File.cd!(tmp, fn ->
         report =
           Analyzer.analyze(
-            [
+            categories: [
               {"Controllers", "lib/**/controllers/**/*.ex"},
               {"Empty", "lib/**/nope/**/*.ex"}
             ],
-            "test/**/*_test.exs"
+            test_pattern: "test/**/*_test.exs"
           )
 
         names = Enum.map(report.categories, fn {name, _} -> name end)


### PR DESCRIPTION
## Summary
- Replaced `Analyzer.analyze(categories, test_pattern)` with `Analyzer.analyze(opts)` taking `:categories` and `:test_pattern` keys.
- Adds an `@type option` so the supported keys are visible in docs.
- Easier to read at call sites and easier to extend later (e.g. a `:exclude` option, a `:total_label` override).
- Updated `Mix.Tasks.Stats` and the analyzer integration test accordingly.

Pre-1.0 (`0.1.0`), so no deprecation shim — just the new shape.

Closes #8

## Test plan
- [x] `mix test` (14 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)