### PR TITLE
Refactor #9: drop public Analyzer.empty/0

### DIFF
--- a/lib/phx_stats/analyzer.ex
+++ b/lib/phx_stats/analyzer.ex
@@ -21,10 +21,6 @@ defmodule PhxStats.Analyzer do
 
   @empty %{files: 0, lines: 0, loc: 0, modules: 0, functions: 0}
 
-  @doc "Returns a stats map of zeros."
-  @spec empty() :: stats()
-  def empty, do: @empty
-
   @doc """
   Builds a full report given a list of `{name, glob}` categories and a test glob.
 

--- a/test/phx_stats/analyzer_test.exs
+++ b/test/phx_stats/analyzer_test.exs
@@ -65,15 +65,17 @@ defmodule PhxStats.AnalyzerTest do
     end
   end
 
+  @empty_stats %{files: 0, lines: 0, loc: 0, modules: 0, functions: 0}
+
   describe "analyze_file/1" do
     test "returns empty stats when file is missing" do
-      assert Analyzer.analyze_file("does/not/exist.ex") == Analyzer.empty()
+      assert Analyzer.analyze_file("does/not/exist.ex") == @empty_stats
     end
   end
 
   describe "sum_stats/1" do
     test "sums all fields and returns empty for an empty list" do
-      assert Analyzer.sum_stats([]) == Analyzer.empty()
+      assert Analyzer.sum_stats([]) == @empty_stats
 
       a = %{files: 1, lines: 10, loc: 8, modules: 1, functions: 2}
       b = %{files: 2, lines: 30, loc: 25, modules: 3, functions: 5}


### PR DESCRIPTION
## Summary
- Removed `Analyzer.empty/0`. Nothing outside the module needs it; exposing it leaked the internal stats-map shape as part of the public API.
- The two tests that referenced it now define a local `@empty_stats` fixture.

Closes #9

## Test plan
- [x] `mix test` (14 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)